### PR TITLE
Fedora 22, Ruby 2.1.7 upgrades, Ansible 1.9.4 compatibility

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/fedora-20"
+  config.vm.box = "bento/fedora-22"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/playbook.yml
+++ b/playbook.yml
@@ -30,13 +30,13 @@
       sudo: no
       shell: "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3"
 
-    - name: Install RVM with Ruby 2.1.7
+    - name: Install RVM with Ruby 2.2.3
       sudo: no
-      shell: "curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.7"
+      shell: "curl -sSL https://get.rvm.io | bash -s stable --ruby=2.2.3"
 
     - name: Set default RVM Ruby
       sudo: no
-      shell: rvm alias create default ruby-2.1.7
+      shell: rvm alias create default ruby-2.2.3
 
     - name: Ensure MySQL/MariaDB is running
       command: systemctl start mariadb

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,41 +5,41 @@
   gather_facts: True
   tasks:
     - name: Update the OS
-      yum: name=* state=latest
+      dnf: name=* state=latest
 
     - name: Install MySQL/MariaDB
-      yum: name=mysql-server state=installed
+      dnf: name=mysql-server state=installed
 
     # Required for Ansible to configure MySQL
     - name: Install MySQL-python
-      yum: name=MySQL-python state=installed
+      dnf: name=MySQL-python state=installed
 
     - name: Install MySQL-dev
-      yum: name=mysql-devel state=installed
+      dnf: name=mysql-devel state=installed
 
     - name: Install git
-      yum: name=git state=installed
+      dnf: name=git state=installed
 
     - name: vim
-      yum: name=vim-enhanced state=installed
+      dnf: name=vim-enhanced state=installed
 
     - name: Install system ruby
-      yum: name=ruby state=installed
+      dnf: name=ruby state=installed
 
     - name: Setup keys for RVM
       sudo: no
       shell: "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3"
 
-    - name: Install RVM with Ruby 2.1.4
+    - name: Install RVM with Ruby 2.1.7
       sudo: no
-      shell: "curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.4"
+      shell: "curl -sSL https://get.rvm.io | bash -s stable --ruby=2.1.7"
 
     - name: Set default RVM Ruby
       sudo: no
-      shell: rvm alias create default ruby-2.1.4
+      shell: rvm alias create default ruby-2.1.7
 
     - name: Ensure MySQL/MariaDB is running
-      service: name=mysqld state=started enabled=true
+      command: systemctl start mariadb
 
     - name: Ensure MySQL/MariaDB starts at boot
       command: systemctl enable mariadb.service


### PR DESCRIPTION
A few fixes to keep this useful development environment up to date:
- Updated the base box to bento/fedora-22. The Bento boxes formerly in Chef organization on Atlas have now been moved to a new organization, Bento.
- Migrated yum commands to the new dnf package manager for recent versions of Ansible.
- Updated Ruby to version 2.1.7.
- Converted to systemctl for auto starting MariaDB.

Tested with:
- Vagrant 1.7.4
- Ansible 1.9.4
- VirtualBox 5.0.10 r104061
