### PR TITLE
Upgrade to Fedora 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ vagrant plugin install vagrant-vbguest
 See https://github.com/dotless-de/vagrant-vbguest for more info.
 
 # What's inside
-1. Fedora 22 fully patched
+1. Fedora 23 fully patched
 2. MySQL/MariaDB Server, Git, and Vim installed
 3. RVM with Ruby 2.2.3
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "bento/fedora-22"
+  config.vm.box = "bento/fedora-23"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,8 +2,14 @@
 - hosts: all
   vars:
     root_db_password:
-  gather_facts: True
+  gather_facts: false
   tasks:
+    - name: install python and deps for ansible modules
+      raw: dnf install -y python2 python2-dnf libselinux-python
+
+    - name: gather facts
+      setup:
+
     - name: Update the OS
       dnf: name=* state=latest
 
@@ -28,7 +34,7 @@
 
     - name: Setup keys for RVM
       sudo: no
-      shell: "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
+      shell: "gpg2 --keyserver hkp://keys.gnupg.net:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
 
     - name: Install RVM with Ruby 2.2.3
       sudo: no
@@ -67,5 +73,3 @@
 
     - name: Test Database is Removed
       mysql_db: name=test state=absent
-
-    - file: dest=/vagrant/repos owner=vagrant group=vagrant state=directory


### PR DESCRIPTION
Fedora 23 includes Python 3, which isn't compatible with Ansible. Skip fact gathering until after installing Python 2.
